### PR TITLE
Automated cherry pick of #11741 #11743 fork release 1.20 bearingpoint

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -42851,7 +42851,7 @@ data:
         prometheus :9253
         health {{ KubeDNS.NodeLocalDNS.LocalIP }}:{{ NodeLocalDNSHealthCheck }}
     }
-    {{- if KubeDNS.NodeLocalDNS.ForwardToKubeDNS }}
+    {{- if WithDefaultBool KubeDNS.NodeLocalDNS.ForwardToKubeDNS false }}
     .:53 {
         errors
         cache 30

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -57,7 +57,7 @@ data:
         prometheus :9253
         health {{ KubeDNS.NodeLocalDNS.LocalIP }}:{{ NodeLocalDNSHealthCheck }}
     }
-    {{- if KubeDNS.NodeLocalDNS.ForwardToKubeDNS }}
+    {{- if WithDefaultBool KubeDNS.NodeLocalDNS.ForwardToKubeDNS false }}
     .:53 {
         errors
         cache 30

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -18,6 +18,7 @@ package openstacktasks
 
 import (
 	"fmt"
+	"sort"
 
 	secgroup "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
@@ -88,6 +89,10 @@ func newPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycl
 			Lifecycle: lifecycle,
 		})
 	}
+
+	// sort for consistent comparison
+	sort.Sort(SecurityGroupsByID(sgs))
+
 	subnets := make([]*Subnet, len(port.FixedIPs))
 	for i, subn := range port.FixedIPs {
 		subnets[i] = &Subnet{
@@ -131,6 +136,10 @@ func (s *Port) Find(context *fi.Context) (*Port, error) {
 	} else if len(rs) != 1 {
 		return nil, fmt.Errorf("found multiple ports with name: %s", fi.StringValue(s.Name))
 	}
+
+	// sort for consistent comparison
+	sort.Sort(SecurityGroupsByID(s.SecurityGroups))
+
 	return newPortTaskFromCloud(cloud, s.Lifecycle, &rs[0], s)
 }
 

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
@@ -38,6 +38,15 @@ type SecurityGroup struct {
 	Lifecycle        *fi.Lifecycle
 }
 
+// SecurityGroupsByID implements sort.Interface based on the ID field.
+type SecurityGroupsByID []*SecurityGroup
+
+func (a SecurityGroupsByID) Len() int      { return len(a) }
+func (a SecurityGroupsByID) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a SecurityGroupsByID) Less(i, j int) bool {
+	return fi.StringValue(a[i].ID) < fi.StringValue(a[j].ID)
+}
+
 var _ fi.CompareWithID = &SecurityGroup{}
 
 func (s *SecurityGroup) CompareWithID() *string {


### PR DESCRIPTION
Cherry pick of #11741 #11743 on release-1.21.

#11741: Compare OpenStack security groups deterministically
#11743: Make forwardToKubeDNS work in the NodeLocal DNSCache template

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
